### PR TITLE
fix!: make stream return each item instead of chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,24 +54,16 @@ ssb.storageUsed.stats((err, stats) => {
 })
 ```
 
-### `ssb.storageUsed.stream(): PullStream<Chunk> (muxrpc "source")`
+### `ssb.storageUsed.stream(): PullStream<[feedId, bytes]> (muxrpc "source")`
 
-Get a pull stream that sends a `Chunk`s sorted by feeds taking up the most storage to the least. A `Chunk` is an array of objects, where each object has the following fields:
-
-  - `feed`: the feed id
-  - `total`: the total number of bytes used by the feed
-
-The items in each chunk are sorted from the highest to lowest `total` values.
+Get a pull stream that sends a tuple where the first item is the feed id and the second item is the number of bytes used by that feed. The items returned by the stream are sorted from the highest to lowest `bytes` values.
 
 ```js
 pull(
   ssb.storageUsed.stream(),
-  pull.drain((chunk) => {
-    console.log(`Chunk has ${chunk.length} feeds`)
-
-    chunk.forEach(item => {
-      console.log(`${item.feed} uses ${item.total} bytes`)
-    })
+  pull.map((item) => {
+    const [feedId, bytes] = item
+    console.log(`Feed ${feedId} uses ${bytes} bytes`)
   })
 )
 ```

--- a/plugin.js
+++ b/plugin.js
@@ -163,8 +163,8 @@ module.exports = class StorageUsed extends Plugin {
           cb(
             null,
             chunk
-              .map((c) => ({ feed: c.key, total: toInt(c.value) }))
-              .sort((a, b) => b.total - a.total)
+              .map((c) => [c.key, toInt(c.value)])
+              .sort((a, b) => b[1] - a[1])
           )
         })
       )
@@ -172,7 +172,9 @@ module.exports = class StorageUsed extends Plugin {
 
     return pull(
       chunkedStream,
-      pull.filter((chunk) => chunk.length > 0)
+      pull.filter((chunk) => chunk.length > 0),
+      pull.map(pull.values),
+      pull.flatten()
     )
   }
 


### PR DESCRIPTION
as pointed out by @staltz , consumers of this module won't care about receiving a stream of chunks (i.e. an array of sorted items). it's preferable to receive a stream of items instead.

this commit also changes the signature of item used to represent each feed. now it's a tuple containing the feed id and the number of bytes used by it. the stream still returns these items from highest to lowest bytes value