### PR TITLE
fix: return proper feed id in stream method

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "ssb-db2": "^4.2.0",
     "ssb-fixtures": "^3.0.4",
     "ssb-keys": "^8.4.0",
+    "ssb-ref": "^2.16.0",
     "standard-version": "^9.5.0",
     "tap-arc": "^0.3.4",
     "tape": "^5.5.3",

--- a/plugin.js
+++ b/plugin.js
@@ -163,7 +163,11 @@ module.exports = class StorageUsed extends Plugin {
           cb(
             null,
             chunk
-              .map((c) => [c.key, toInt(c.value)])
+              .map((c) => {
+                const feedId = self._unpackKey(c.key)[1]
+                const bytes = toInt(c.value)
+                return /** @type {const} */ ([feedId, bytes])
+              })
               .sort((a, b) => b[1] - a[1])
           )
         })

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ const SecretStack = require('secret-stack')
 const caps = require('ssb-caps')
 const ssbKeys = require('ssb-keys')
 const pull = require('pull-stream')
+const Ref = require('ssb-ref')
 
 const SEED = 'tiny'
 const MESSAGES = 1000
@@ -101,7 +102,10 @@ test('stream', (t) => {
     sbot.storageUsed.stream(),
     pull.map((item) => {
       const [feedId, bytes] = item
+
       t.equal(typeof feedId, 'string', 'item[0] is a string')
+      t.ok(Ref.isFeed(feedId), 'item[0] is a valid feed id')
+
       t.equal(typeof bytes, 'number', 'item[1] is a number')
 
       return item


### PR DESCRIPTION
the stream was returning the _prefixed_ feed ids so we'd get results like `['01@...', ...]` where the prefix is the chunk group used internally 