### PR TITLE
Fix disappeared large feeds from prefix 00

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -134,7 +134,6 @@ module.exports = class StorageUsed extends Plugin {
    * @returns {number}
    */
   getBytesStored(feedId) {
-    const prefix = this.feedIdToPrefix.get(feedId)
     return this.bytesStored.get(feedId) || 0
   }
 
@@ -203,7 +202,10 @@ module.exports = class StorageUsed extends Plugin {
   _calculatePrefix(bufferLength) {
     // If actual total is less than 1kb, round up to 1kb
     const kbTotal = Math.max(bufferLength, 1024) / 1024
-    const prefix = 99 - Math.floor(Math.log2(kbTotal) * PREFIX_FACTOR)
+    const prefix = Math.max(
+      0,
+      99 - Math.floor(Math.log2(kbTotal) * PREFIX_FACTOR)
+    )
     return this._createPrefixString(prefix)
   }
 

--- a/plugin.js
+++ b/plugin.js
@@ -148,7 +148,7 @@ module.exports = class StorageUsed extends Plugin {
      */
     function chunkedStream(errOrEnd, cb) {
       if (errOrEnd) return cb(errOrEnd)
-      if (++prefix >= 100) return cb(true)
+      if (prefix >= 100) return cb(true)
 
       const stringPrefix = self._createPrefixString(prefix)
 
@@ -160,6 +160,7 @@ module.exports = class StorageUsed extends Plugin {
           values: true,
         }),
         pull.collect((err, chunk) => {
+          prefix++
           cb(
             null,
             chunk


### PR DESCRIPTION
## Problem

The first chunk considered for the `stream()` was `01`, skipping items with prefix `00`. The issue was caused by the `++prefix` increment happening too early.

Another problem is that for feeds that technically are "larger" than the `00` bucket would allow, should also be considered to be in `00` (because there is no other larger bucket than that), but in practice a `-1` bucket was being calculated.

## Solution

The solution is to increment the prefix counter only *after* we have read all items with that prefix. Also, to cap the prefix at `00` lowest.

The first commit introduces changes to the test suite that prove that the current implementation fails, i.e. reproduces the problem. The second commit introduces fixes that make the test suite pass. (I call this pattern 1st :x: 2nd :heavy_check_mark:)