### PR TITLE
add log stats to the stats() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ ssb.storageUsed.getBytesStored(ssb.id, (err, bytesStored) => {
     - `indexes: number`
     - `jitIndexes: number`
     - `log: number`
+    - `logUsedBytes: number`
+    - `logDeletedBytes: number`
   - `err` will return the **first** error that occurs when checking the various directories
 
-Get information about how much disk space `ssb/db2` takes up. This includes the log file, the indexes directories, and the blobs directories.
+Get information about how much disk space `ssb/db2` takes up. This includes the log file, the indexes directories, and the blobs directories. Additionally, `logUsedBytes` and `logDeletedBytes` are statistics about the internals of the log file, and come from [async-append-only-log](https://github.com/ssbc/async-append-only-log)'s `stats` method.
 
 ```js
 ssb.storageUsed.stats((err, stats) => {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = {
      */
     function stats(cb) {
       ssb.db.onDrain('storageUsed', () => {
-        getStats(config.path, cb)
+        getStats(ssb, config.path, cb)
       })
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -78,6 +78,8 @@ test('stats', (t) => {
     t.error(err, 'no error')
     t.equal(stats.blobs, 0, 'blob size is 0')
     t.ok(stats.indexes > 0, 'indexes is non-zero')
+    t.ok(stats.logUsedBytes > 0, 'log records are non-zero')
+    t.equal(stats.logDeletedBytes , 0, 'log deleted records are zero')
     t.equal(stats.jitIndexes, 0, 'jit indexes is 0')
     t.equal(
       stats.log,

--- a/types/helpers.d.ts
+++ b/types/helpers.d.ts
@@ -7,11 +7,21 @@ export interface CB<T> {
   (err: any, val?: T): void
 }
 
+export interface LogStats {
+  totalBytes: number
+  totalCount: number
+  deletedBytes: number
+  deletedCount: number
+}
+
 export interface SSB {
   db?: {
     getIndex: CallableFunction
     onDrain: CallableFunction
     registerIndex: CallableFunction
+    getLog: () => {
+      stats: (cb: CB<LogStats>) => void
+    }
   }
 }
 
@@ -23,5 +33,6 @@ export type StatsPromiseFulfilledResults = [
   PromiseFulfilledResult<number>,
   PromiseFulfilledResult<number>,
   PromiseFulfilledResult<number>,
-  PromiseFulfilledResult<number>
+  PromiseFulfilledResult<number>,
+  PromiseFulfilledResult<LogStats>
 ]


### PR DESCRIPTION
We need a way of knowing how many records (in total bytes) are *deleted*, so this PR updates the `stats` function to return more details.

Also `stats.logUsedBytes` is almost the same as `stats.log`, but may be useful for someone. The difference is that `stats.log` comes from the filesystem, while `stats.logUsedBytes` looks inside the file and represents all of the *readable* portion of the file. You would assume that the entire file is readable, but the way that async-append-only-log works is by blocks, so if you have only **one** record, the `stats.logUsedBytes` will be approximately 500 bytes, while the `stats.log` will be 64kB because the "block size" is 64kB.