### PR TITLE
fix!: feed bytesUsed contains indexes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-const path = require('path')
 const pull = require('pull-stream')
+// @ts-ignore
+const deferred = require('pull-defer')
 
 const getStats = require('./stats')
 const IndexPlugin = require('./plugin')
@@ -33,6 +34,20 @@ module.exports = {
     ssb.db.registerIndex(IndexPlugin)
 
     /**
+     * Determine how many bytes a feed is using on the log, and (on average)
+     * how many bytes it is using for indexes, and add them up.
+     * @param {number} logBytes
+     * @param {*} info
+     * @returns {number}
+     */
+    function sumLogAndIndexes(logBytes, info) {
+      const totalLogBytes = info.logUsedBytes
+      const proportion = logBytes / totalLogBytes
+      const indexesBytes = proportion * (info.indexes + info.jitIndexes)
+      return logBytes + indexesBytes
+    }
+
+    /**
      * Get the storage capacity used for a specfic feed id
      * @param {string} feedId
      * @param {import('./types/helpers').CB<*>} cb
@@ -40,8 +55,13 @@ module.exports = {
     function getBytesStored(feedId, cb) {
       /** @type {IndexPlugin} */
       const indexPlugin = ssb.db.getIndex('storageUsed')
-      ssb.db.onDrain('storageUsed', () => {
-        cb(null, indexPlugin.getBytesStored(feedId))
+      stats((err, info) => {
+        if (err) return cb(err)
+        ssb.db.onDrain('storageUsed', () => {
+          const logBytes = indexPlugin.bytesStored.get(feedId)
+          if (logBytes == null) return cb(null, 0)
+          cb(null, sumLogAndIndexes(logBytes, info))
+        })
       })
     }
 
@@ -49,15 +69,27 @@ module.exports = {
      * @param {import('./types/helpers').CB<*>} cb
      */
     function stats(cb) {
-      ssb.db.onDrain('storageUsed', () => {
-        getStats(ssb, config.path, cb)
-      })
+      getStats(ssb, config.path, cb)
     }
 
     function stream() {
       /** @type {IndexPlugin} */
       const indexPlugin = ssb.db.getIndex('storageUsed')
-      return indexPlugin.stream()
+      const source = deferred.source()
+      stats((err, info) => {
+        source.resolve(
+          err
+            ? pull.error(err)
+            : pull(
+                indexPlugin.stream(),
+                pull.map(([feedId, logBytes]) => [
+                  feedId,
+                  sumLogAndIndexes(logBytes, info),
+                ])
+              )
+        )
+      })
+      return source
     }
 
     return { getBytesStored, stats, stream }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "bipf": "^1.9.0",
     "clarify-error": "^1.0.0",
+    "pull-defer": "^0.2.3",
     "pull-level": "^2.0.4",
     "pull-stream": "^3.6.14",
     "trammel": "~4.0.0"

--- a/plugin.js
+++ b/plugin.js
@@ -137,6 +137,9 @@ module.exports = class StorageUsed extends Plugin {
     return this.bytesStored.get(feedId) || 0
   }
 
+  /**
+   * @returns {pull.Source<[string, number]>}
+   */
   stream() {
     const self = this
     let prefix = 0
@@ -174,6 +177,7 @@ module.exports = class StorageUsed extends Plugin {
       )
     }
 
+    // @ts-ignore
     return pull(
       chunkedStream,
       pull.filter((chunk) => chunk.length > 0),


### PR DESCRIPTION
## Problem

Technically, if there are zero feeds, there is zero bytes used up by indexes. This means that feeds are responsible for indexes bytes, but currently those bytes are not taken into account when we're viewing the bytesUsed for a feed.

## Solution

Take an average. Based on the proportion of a feed bytesUsed relative to the full log, infer how much of the indexes is due to that feed.