### PR TITLE
fix: allow using ssb-db2 greater than 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "trammel": "~4.0.0"
   },
   "peerDependencies": {
-    "ssb-db2": "^4.2.0"
+    "ssb-db2": ">=4.2.0"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",


### PR DESCRIPTION
Context: updating nodejs-mobile-react-native to 16.17.0

Problem: npm install fails due to conflicting peer dependencies

Solution: we should allow ssb-db2 5.x, 6.x and above as peer dep